### PR TITLE
ci(github): Run build and check when opening pull requests

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -1,6 +1,6 @@
 name: Build and release
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build_stubs:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,6 @@
 name: pre-commit checks
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   pre_commit_checks:


### PR DESCRIPTION
All github actions were triggered in https://github.com/espressif/esptool-legacy-flasher-stub/pull/2 because I was "push"ing there. https://github.com/espressif/esptool-legacy-flasher-stub/pull/5 was opened but neither the build nor all checks were triggered, so I cannot compare the stub binary from artifacts with the one in the esptool repository.

I hope this will solve this issue.