### PR TITLE
feat(esp32p4): Add support for >16 MB flash sizes

### DIFF
--- a/flasher_stub/include/rom_functions.h
+++ b/flasher_stub/include/rom_functions.h
@@ -181,7 +181,7 @@ typedef struct {
 UartDevice * GetUartDevice();
 #endif // WITH_USB_JTAG_SERIAL || WITH_USB_OTG
 
-#if defined(ESP32S3)
+#if defined(ESP32S3) || defined(ESP32P4)
 #define BIT(nr)                 (1UL << (nr))
 #define ESP_ROM_OPIFLASH_SEL_CS0     (BIT(0))
 
@@ -348,6 +348,27 @@ void esp_rom_opiflash_exec_cmd(int spi_num, SpiFlashRdMode mode,
     uint32_t cs_mask,
     bool is_write_erase_operation);
 
+#if ESP32P4
+extern uint32_t _rom_eco_version; // rom constant to define ECO version
+void esp_rom_opiflash_exec_cmd_eco1(int spi_num, SpiFlashRdMode mode,
+    uint32_t cmd, int cmd_bit_len,
+    uint32_t addr, int addr_bit_len,
+    int dummy_bits,
+    uint8_t* mosi_data, int mosi_bit_len,
+    uint8_t* miso_data, int miso_bit_len,
+    uint32_t cs_mask,
+    bool is_write_erase_operation);
+
+void esp_rom_opiflash_exec_cmd_eco2(int spi_num, SpiFlashRdMode mode,
+    uint32_t cmd, int cmd_bit_len,
+    uint32_t addr, int addr_bit_len,
+    int dummy_bits,
+    uint8_t* mosi_data, int mosi_bit_len,
+    uint8_t* miso_data, int miso_bit_len,
+    uint32_t cs_mask,
+    bool is_write_erase_operation);
+#endif // ESP32P4
+
 esp_rom_spiflash_result_t esp_rom_opiflash_wait_idle();
 esp_rom_spiflash_result_t esp_rom_opiflash_wren();
 esp_rom_spiflash_result_t esp_rom_opiflash_erase_sector(uint32_t sector_num);
@@ -358,4 +379,4 @@ void esp_rom_spiflash_write_encrypted_enable();
 void esp_rom_spiflash_write_encrypted_disable();
 SpiFlashOpResult esp_rom_spiflash_unlock();
 SpiFlashOpResult esp_rom_spiflash_wait_idle(void);
-#endif // ESP32S3
+#endif // ESP32S3 || ESP32P4

--- a/flasher_stub/include/soc_support.h
+++ b/flasher_stub/include/soc_support.h
@@ -662,15 +662,26 @@
  * AES-XTS peripheral
  */
 
-#if ESP32S3
 #define MAX_ENCRYPT_BLOCK 64
 
-#define AES_XTS_PLAIN_BASE               ((DR_REG_AES_XTS_BASE) + 0x00)
-#define AES_XTS_SIZE_REG                 ((DR_REG_AES_XTS_BASE) + 0x40)
-#define AES_XTS_DESTINATION_REG          ((DR_REG_AES_XTS_BASE) + 0x44)
-#define AES_XTS_PHYSICAL_ADDR_REG        ((DR_REG_AES_XTS_BASE) + 0x48)
-#define AES_XTS_TRIGGER_REG              ((DR_REG_AES_XTS_BASE) + 0x4C)
-#define AES_XTS_RELEASE_REG              ((DR_REG_AES_XTS_BASE) + 0x50)
-#define AES_XTS_DESTROY_REG              ((DR_REG_AES_XTS_BASE) + 0x54)
-#define AES_XTS_STATE_REG                ((DR_REG_AES_XTS_BASE) + 0x58)
+#if ESP32S3
+#define AES_XTS_PLAIN_BASE               (DR_REG_AES_XTS_BASE + 0x00)
+#define AES_XTS_SIZE_REG                 (DR_REG_AES_XTS_BASE + 0x40)
+#define AES_XTS_DESTINATION_REG          (DR_REG_AES_XTS_BASE + 0x44)
+#define AES_XTS_PHYSICAL_ADDR_REG        (DR_REG_AES_XTS_BASE + 0x48)
+#define AES_XTS_TRIGGER_REG              (DR_REG_AES_XTS_BASE + 0x4C)
+#define AES_XTS_RELEASE_REG              (DR_REG_AES_XTS_BASE + 0x50)
+#define AES_XTS_DESTROY_REG              (DR_REG_AES_XTS_BASE + 0x54)
+#define AES_XTS_STATE_REG                (DR_REG_AES_XTS_BASE + 0x58)
 #endif // ESP32S3
+
+#if ESP32P4
+#define AES_XTS_PLAIN_BASE               (SPI0_BASE_REG + 0x300)
+#define AES_XTS_SIZE_REG                 (SPI0_BASE_REG + 0x340)
+#define AES_XTS_DESTINATION_REG          (SPI0_BASE_REG + 0x344)
+#define AES_XTS_PHYSICAL_ADDR_REG        (SPI0_BASE_REG + 0x348)
+#define AES_XTS_TRIGGER_REG              (SPI0_BASE_REG + 0x34C)
+#define AES_XTS_RELEASE_REG              (SPI0_BASE_REG + 0x350)
+#define AES_XTS_DESTROY_REG              (SPI0_BASE_REG + 0x354)
+#define AES_XTS_STATE_REG                (SPI0_BASE_REG + 0x358)
+#endif // ESP32P4

--- a/flasher_stub/include/stub_flasher.h
+++ b/flasher_stub/include/stub_flasher.h
@@ -20,8 +20,8 @@
 #define FLASH_STATUS_MASK 0xFFFF
 #define SECTORS_PER_BLOCK (FLASH_BLOCK_SIZE / FLASH_SECTOR_SIZE)
 
-/* 32-bit addressing is supported only by ESP32S3 */
-#if defined(ESP32S3) && !defined(ESP32S3BETA2)
+/* 32-bit addressing is supported only by ESP32S3 and ESP32P4 */
+#if (ESP32S3 && !ESP32S3BETA2) || ESP32P4
 #define FLASH_MAX_SIZE 64*1024*1024
 extern bool large_flash_mode;
 #else

--- a/flasher_stub/include/stub_write_flash.h
+++ b/flasher_stub/include/stub_write_flash.h
@@ -26,5 +26,9 @@ void handle_flash_encrypt_data(void *data_buf, uint32_t length);
 
 void handle_flash_deflated_data(void *data_buf, uint32_t length);
 
+#if ESP32P4
+void spi_write_enable(void);
+#endif
+
 /* same command used for deflated or non-deflated mode */
 esp_command_error handle_flash_end(void);

--- a/flasher_stub/ld/rom_32p4.ld
+++ b/flasher_stub/ld/rom_32p4.ld
@@ -77,6 +77,9 @@ ets_set_user_start = 0x4fc000c4;
 ets_rom_layout_p = 0x4fc1fffc;
 ets_ops_table_ptr = 0x4ff3fff4;
 g_saved_pc = 0x4ff3fff8;
+memcpy = 0x4fc0026c;
+esp_rom_opiflash_exec_cmd_eco1 = 0x4fc0fe76;
+esp_rom_opiflash_exec_cmd_eco2 = 0x4fc10320;
 
 
 /***************************************
@@ -617,3 +620,12 @@ usb_dev_deinit = 0x4fc00a44;
 usb_dw_ctrl_deinit = 0x4fc00a48;
 /* Data (.data, .bss, .rodata) */
 s_usb_osglue = 0x4ff3ffc8;
+
+
+/***************************************
+ ROM version variables for esp32p4
+ These addresses should be compatible with any ROM version for this chip.
+ ***************************************/
+
+_rom_chip_id = 0x4fc00010;
+_rom_eco_version = 0x4fc00014;


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
- Add the ability to read, write, and erase octal flash chips larger than 16 MB on the ESP32-P4 by enabling 32bit addressing.
- Touches the related implementation on ESP32-S3 to avoid code duplication when possible by replacing `opiflash` calls with `spiflash` if needed (`opiflash` functions are not available on the P4).

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

- The P4 and S3 stub files have been put through esptool CI with positive results.
- A customer confirmed that the P4 implementation works.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
