### PR TITLE
Fix USB-Serial/JTAG on ESP32-C5 ECO2 and ESP32-C61 ECO3 + update toolchain

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -20,12 +20,10 @@ jobs:
         export TOOLCHAIN_DIR=$HOME/toolchain
 
         export ESP8266_BINDIR=$TOOLCHAIN_DIR/xtensa-lx106-elf/bin
-        export ESP32_BINDIR=$TOOLCHAIN_DIR/xtensa-esp32-elf/bin
-        export ESP32S2_BINDIR=$TOOLCHAIN_DIR/xtensa-esp32s2-elf/bin
-        export ESP32S3_BINDIR=$TOOLCHAIN_DIR/xtensa-esp32s3-elf/bin
-        export ESP32C3_BINDIR=$TOOLCHAIN_DIR/riscv32-esp-elf/bin
+        export XTENSA_BINDIR=$TOOLCHAIN_DIR/xtensa-esp-elf/bin
+        export RISCV_BINDIR=$TOOLCHAIN_DIR/riscv32-esp-elf/bin
 
-        export PATH=$PATH:$ESP8266_BINDIR:$ESP32_BINDIR:$ESP32S2_BINDIR:$ESP32S3_BINDIR:$ESP32C3_BINDIR
+        export PATH=$PATH:$ESP8266_BINDIR:$XTENSA_BINDIR:$RISCV_BINDIR
 
         ./ci/setup_ci_build_env.sh
         make -C flasher_stub V=1

--- a/ci/setup_ci_build_env.sh
+++ b/ci/setup_ci_build_env.sh
@@ -3,10 +3,8 @@
 set -exuo pipefail
 
 ESP8266_TOOLCHAIN_URL="https://dl.espressif.com/dl/xtensa-lx106-elf-linux64-1.22.0-92-g8facf4c-5.2.0.tar.gz"
-ESP32_TOOLCHAIN_URL="https://github.com/espressif/crosstool-NG/releases/download/esp-2022r1/xtensa-esp32-elf-gcc11_2_0-esp-2022r1-linux-amd64.tar.xz"
-ESP32S2_TOOLCHAIN_URL="https://github.com/espressif/crosstool-NG/releases/download/esp-2022r1/xtensa-esp32s2-elf-gcc11_2_0-esp-2022r1-linux-amd64.tar.xz"
-ESP32S3_TOOLCHAIN_URL="https://github.com/espressif/crosstool-NG/releases/download/esp-2022r1/xtensa-esp32s3-elf-gcc11_2_0-esp-2022r1-linux-amd64.tar.xz"
-ESP32C3_TOOLCHAIN_URL="https://github.com/espressif/crosstool-NG/releases/download/esp-2022r1/riscv32-esp-elf-gcc11_2_0-esp-2022r1-linux-amd64.tar.xz"
+XTENSA_TOOLCHAIN_URL="https://github.com/espressif/crosstool-NG/releases/download/esp-15.1.0_20250607/xtensa-esp-elf-15.1.0_20250607-x86_64-linux-gnu.tar.xz"
+RISCV_TOOLCHAIN_URL="https://github.com/espressif/crosstool-NG/releases/download/esp-15.1.0_20250607/riscv32-esp-elf-15.1.0_20250607-x86_64-linux-gnu.tar.xz"
 
 # Setup shell script to download & configure ESP8266 & ESP32 toolchains
 # for building the flasher stub program
@@ -19,26 +17,14 @@ if ! [ -d ${ESP8266_BINDIR} ]; then
     tar zxf $(basename ${ESP8266_TOOLCHAIN_URL})
 fi
 
-if ! [ -d ${ESP32_BINDIR} ]; then
+if ! [ -d ${XTENSA_BINDIR} ]; then
     # gitlab CI image may already have this file
-    wget --continue --no-verbose "${ESP32_TOOLCHAIN_URL}"
-    tar Jxf $(basename ${ESP32_TOOLCHAIN_URL})
+    wget --continue --no-verbose "${XTENSA_TOOLCHAIN_URL}"
+    tar Jxf $(basename ${XTENSA_TOOLCHAIN_URL})
 fi
 
-if ! [ -d ${ESP32S2_BINDIR} ]; then
+if ! [ -d ${RISCV_BINDIR} ]; then
     # gitlab CI image may already have this file
-    wget --continue --no-verbose "${ESP32S2_TOOLCHAIN_URL}"
-    tar Jxf $(basename ${ESP32S2_TOOLCHAIN_URL})
-fi
-
-if ! [ -d ${ESP32S3_BINDIR} ]; then
-    # gitlab CI image may already have this file
-    wget --continue --no-verbose "${ESP32S3_TOOLCHAIN_URL}"
-    tar Jxf $(basename ${ESP32S3_TOOLCHAIN_URL})
-fi
-
-if ! [ -d ${ESP32C3_BINDIR} ]; then
-    # gitlab CI image may already have this file
-    wget --continue --no-verbose "${ESP32C3_TOOLCHAIN_URL}"
-    tar Jxf $(basename ${ESP32C3_TOOLCHAIN_URL})
+    wget --continue --no-verbose "${RISCV_TOOLCHAIN_URL}"
+    tar Jxf $(basename ${RISCV_TOOLCHAIN_URL})
 fi

--- a/flasher_stub/include/soc_support.h
+++ b/flasher_stub/include/soc_support.h
@@ -381,7 +381,7 @@
 #define UART_USB_JTAG_SERIAL  3
 
 #define DR_REG_INTERRUPT_MATRIX_BASE            0x60010000
-#define INTERRUPT_CORE0_USB_INTR_MAP_REG        (DR_REG_INTERRUPT_MATRIX_BASE + 0xD0) /* USB-JTAG-Serial, INTMTX_CORE0_USB_INTR_MAP_REG */
+#define INTERRUPT_CORE0_USB_INTR_MAP_REG        (DR_REG_INTERRUPT_MATRIX_BASE + 0xD8) /* USB-JTAG-Serial, INTERRUPT_CORE0_USB_SERIAL_JTAG_INTR_MAP_REG */
 
 #define CLIC_EXT_INTR_NUM_OFFSET 16  /* For CLIC first 16 interrupts are reserved as internal */
 #define ETS_USB_INUM 17  /* arbitrary level 1 level interrupt */

--- a/flasher_stub/include/soc_support.h
+++ b/flasher_stub/include/soc_support.h
@@ -368,10 +368,10 @@
 #endif // ESP32C6
 
 #if ESP32C61
-#define UART_USB_JTAG_SERIAL  3
+#define UART_USB_JTAG_SERIAL  4
 
 #define DR_REG_INTERRUPT_MATRIX_BASE            0x60010000
-#define INTERRUPT_CORE0_USB_INTR_MAP_REG        (DR_REG_INTERRUPT_MATRIX_BASE + 0xa8) /* USB-JTAG-Serial, INTMTX_CORE0_USB_INTR_MAP_REG */
+#define INTERRUPT_CORE0_USB_INTR_MAP_REG        (DR_REG_INTERRUPT_MATRIX_BASE + 0xB0) /* USB-JTAG-Serial, INTMTX_CORE0_USB_INTR_MAP_REG */
 
 #define CLIC_EXT_INTR_NUM_OFFSET 16  /* For CLIC first 16 interrupts are reserved as internal */
 #define ETS_USB_INUM 17  /* arbitrary level 1 level interrupt */


### PR DESCRIPTION
## Description

- Fixed USB-SerialJTAG mode on the `ESP32-C5 ECO2` and `ESP32-C61 ECO3`.
- Updated the toolchains to the latest [esp-15.1.0_20250607](https://github.com/espressif/crosstool-NG/releases/tag/esp-15.1.0_20250607)[esp-15.1.0_20250607](https://github.com/espressif/crosstool-NG/releases/tag/esp-15.1.0_20250607) pre-release.
   - Simplified the prepare toolchains CI workflow using the new unified Xtensa toolchain with multi-lib (used since [esp-13.2.0_20230928](https://github.com/espressif/crosstool-NG/releases/tag/esp-13.2.0_20230928)) for `esp32`/`esp32s2`/`esp32s3`. Kept using the provided binary wrappers `xtensa-esp32-elf-*`/`xtensa-esp32s2-elf-*`/`xtensa-esp32s3-elf-*` for compatibility (these are little-endian) instead of the unified `xtensa-esp-elf-gcc` (which is big-endian).

## Testing

- Successfully ran the esptool CI pipeline with the updated JSON stub files.