### PR TITLE
Release v1.6.0 (EP32-C5 ECO2 + ESP32-C61 ECO3 fixes + toolchain update) 

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,5 +1,5 @@
 [tool.commitizen]
-version = "1.5.1"
+version = "1.6.0"
 update_changelog_on_bump = true
 tag_format = "v$version"
 changelog_start_rev = "v1.0.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v1.6.0 (2025-06-17)
+
+### New Features
+
+- **toolchain**: Update toolchain to esp-15.1.0_20250607
+
+### Bug Fixes
+
+- **esp32c61eco3**: Fix USB-Serial/JTAG mode
+- **esp32c5eco2**: Fix USB-Serial/JTAG mode
+
 ## v1.5.1 (2025-05-13)
 
 ### Bug Fixes


### PR DESCRIPTION
### New Features

- Updated the toolchain to [esp-15.1.0_20250607](https://github.com/espressif/crosstool-NG/releases/tag/esp-15.1.0_20250607)

### Bug Fixes

- **ESP32-C5 ECO2**: Fixed USB-Serial/JTAG mode
- **ESP32-C61 ECO3**: Fixed USB-Serial/JTAG mode