### PR TITLE
feat(esp32c5): Add support for >16 MB flash sizes

### DIFF
--- a/flasher_stub/include/rom_functions.h
+++ b/flasher_stub/include/rom_functions.h
@@ -181,7 +181,7 @@ typedef struct {
 UartDevice * GetUartDevice();
 #endif // WITH_USB_JTAG_SERIAL || WITH_USB_OTG
 
-#if defined(ESP32S3) || defined(ESP32P4)
+#if defined(ESP32S3) || defined(ESP32P4) || defined(ESP32C5)
 #define BIT(nr)                 (1UL << (nr))
 #define ESP_ROM_OPIFLASH_SEL_CS0     (BIT(0))
 
@@ -379,4 +379,4 @@ void esp_rom_spiflash_write_encrypted_enable();
 void esp_rom_spiflash_write_encrypted_disable();
 SpiFlashOpResult esp_rom_spiflash_unlock();
 SpiFlashOpResult esp_rom_spiflash_wait_idle(void);
-#endif // ESP32S3 || ESP32P4
+#endif // ESP32S3 || ESP32P4 || ESP32C5

--- a/flasher_stub/include/soc_support.h
+++ b/flasher_stub/include/soc_support.h
@@ -679,7 +679,7 @@
 #define AES_XTS_STATE_REG                (DR_REG_AES_XTS_BASE + 0x58)
 #endif // ESP32S3
 
-#if ESP32P4
+#if ESP32P4 || ESP32C5
 #define AES_XTS_PLAIN_BASE               (SPI0_BASE_REG + 0x300)
 #define AES_XTS_SIZE_REG                 (SPI0_BASE_REG + 0x340)
 #define AES_XTS_DESTINATION_REG          (SPI0_BASE_REG + 0x344)
@@ -688,4 +688,4 @@
 #define AES_XTS_RELEASE_REG              (SPI0_BASE_REG + 0x350)
 #define AES_XTS_DESTROY_REG              (SPI0_BASE_REG + 0x354)
 #define AES_XTS_STATE_REG                (SPI0_BASE_REG + 0x358)
-#endif // ESP32P4
+#endif // ESP32P4 || ESP32C5

--- a/flasher_stub/include/stub_flasher.h
+++ b/flasher_stub/include/stub_flasher.h
@@ -20,8 +20,8 @@
 #define FLASH_STATUS_MASK 0xFFFF
 #define SECTORS_PER_BLOCK (FLASH_BLOCK_SIZE / FLASH_SECTOR_SIZE)
 
-/* 32-bit addressing is supported only by ESP32S3 and ESP32P4 */
-#if (ESP32S3 && !ESP32S3BETA2) || ESP32P4
+/* 32-bit addressing is supported only by ESP32S3, ESP32P4 and ESP32C5 */
+#if (ESP32S3 && !ESP32S3BETA2) || ESP32P4 || ESP32C5
 #define FLASH_MAX_SIZE 64*1024*1024
 extern bool large_flash_mode;
 #else

--- a/flasher_stub/include/stub_write_flash.h
+++ b/flasher_stub/include/stub_write_flash.h
@@ -26,7 +26,7 @@ void handle_flash_encrypt_data(void *data_buf, uint32_t length);
 
 void handle_flash_deflated_data(void *data_buf, uint32_t length);
 
-#if ESP32P4
+#if ESP32P4 || ESP32C5
 void spi_write_enable(void);
 #endif
 

--- a/flasher_stub/ld/rom_32c5.ld
+++ b/flasher_stub/ld/rom_32c5.ld
@@ -188,6 +188,8 @@ spi_flash_read_encrypted = 0x40000200;
 rom_spiflash_legacy_funcs = 0x4085fff0;
 rom_spiflash_legacy_data = 0x4085ffec;
 g_flash_guard_ops = 0x4085fff4;
+memcpy = 0x40035b86;
+esp_rom_opiflash_exec_cmd = 0x4002c42a;
 
 
 /***************************************

--- a/flasher_stub/stub_commands.c
+++ b/flasher_stub/stub_commands.c
@@ -13,7 +13,7 @@
 #include "soc_support.h"
 #include "stub_io.h"
 
-#if (ESP32S3 && !ESP32S3BETA2) || ESP32P4
+#if (ESP32S3 && !ESP32S3BETA2) || ESP32P4 || ESP32C5
 static esp_rom_spiflash_result_t SPIRead4B(int spi_num, uint32_t flash_addr, uint8_t* buf, int len)
 {
     uint8_t cmd_len = 8;
@@ -41,7 +41,7 @@ static esp_rom_spiflash_result_t SPIRead4B(int spi_num, uint32_t flash_addr, uin
     }
     return ESP_ROM_SPIFLASH_RESULT_OK;
 }
-#endif // ESP32S3
+#endif // ESP32S3 || ESP32P4 || ESP32C5
 
 int handle_flash_erase(uint32_t addr, uint32_t len) {
   if (addr % FLASH_SECTOR_SIZE != 0) return 0x32;
@@ -55,7 +55,7 @@ int handle_flash_erase(uint32_t addr, uint32_t len) {
         } else {
           if (SPIEraseSector(addr / FLASH_SECTOR_SIZE) != 0) return 0x35;
         }
-    #elif ESP32P4
+    #elif ESP32P4 || ESP32C5
         if (large_flash_mode) {
           spi_write_enable();
           esp_rom_spiflash_wait_idle();
@@ -84,7 +84,7 @@ int handle_flash_erase(uint32_t addr, uint32_t len) {
       } else {
         if (SPIEraseBlock(addr / FLASH_BLOCK_SIZE) != 0) return 0x36;
       }
-    #elif ESP32P4
+    #elif ESP32P4 || ESP32C5
       if (large_flash_mode) {
         spi_write_enable();
         esp_rom_spiflash_wait_idle();
@@ -113,7 +113,7 @@ int handle_flash_erase(uint32_t addr, uint32_t len) {
       } else {
         if (SPIEraseSector(addr / FLASH_SECTOR_SIZE) != 0) return 0x37;
       }
-    #elif ESP32P4
+    #elif ESP32P4 || ESP32C5
       if (large_flash_mode) {
         spi_write_enable();
         esp_rom_spiflash_wait_idle();
@@ -157,7 +157,7 @@ void handle_flash_read(uint32_t addr, uint32_t len, uint32_t block_size,
     while (num_sent < len && num_sent - num_acked < max_in_flight) {
       uint32_t n = len - num_sent;
       if (n > block_size) n = block_size;
-      #if (ESP32S3 && !ESP32S3BETA2) || ESP32P4
+      #if (ESP32S3 && !ESP32S3BETA2) || ESP32P4 || ESP32C5
         if (large_flash_mode) {
           res = SPIRead4B(1, addr, buf, n);
         } else {
@@ -197,7 +197,7 @@ int handle_flash_get_md5sum(uint32_t addr, uint32_t len) {
     if (n > FLASH_SECTOR_SIZE) {
       n = FLASH_SECTOR_SIZE;
     }
-    #if (ESP32S3 && !ESP32S3BETA2) || ESP32P4
+    #if (ESP32S3 && !ESP32S3BETA2) || ESP32P4 || ESP32C5
       if (large_flash_mode) {
         res = SPIRead4B(1, addr, buf, n);
       } else {

--- a/flasher_stub/stub_flasher.c
+++ b/flasher_stub/stub_flasher.c
@@ -156,7 +156,7 @@ static void disable_watchdogs()
 }
 #endif // WITH_USB_JTAG_SERIAL
 
-#if (ESP32S3 && !ESP32S3BETA2) || ESP32P4
+#if (ESP32S3 && !ESP32S3BETA2) || ESP32P4 || ESP32C5
 bool large_flash_mode = false;
 
 bool flash_larger_than_16mb()
@@ -174,7 +174,7 @@ bool flash_larger_than_16mb()
   uint8_t flid_lowbyte = (flash_id >> 16) & 0xFF;
   return ((flid_lowbyte >= 0x19 && flid_lowbyte < 0x30) || (flid_lowbyte >= 0x39)); // See DETECTED_FLASH_SIZES in esptool
 }
-#endif // (ESP32S3 && !ESP32S3BETA2) || ESP32P4
+#endif // (ESP32S3 && !ESP32S3BETA2) || ESP32P4 || ESP32C5
 
 static void stub_handle_rx_byte(char byte)
 {
@@ -556,7 +556,7 @@ void stub_main()
       esp_rom_opiflash_legacy_driver_init(&flash_driver);
       esp_rom_opiflash_wait_idle();
     }
-  #elif ESP32P4
+  #elif ESP32P4 || ESP32C5
     large_flash_mode = flash_larger_than_16mb();
   #endif //ESP32S3 && !ESP32S3BETA2
   SPIParamCfg(0, FLASH_MAX_SIZE, FLASH_BLOCK_SIZE, FLASH_SECTOR_SIZE,

--- a/flasher_stub/stub_write_flash.c
+++ b/flasher_stub/stub_write_flash.c
@@ -136,7 +136,7 @@ SpiFlashOpResult SPIUnlock(void)
 }
 #endif // ESP32_OR_LATER
 
-#if (ESP32S3 && !ESP32S3BETA2) || ESP32P4
+#if (ESP32S3 && !ESP32S3BETA2) || ESP32P4 || ESP32C5
 static esp_rom_spiflash_result_t page_program_internal(int spi_num, uint32_t spi_addr, uint8_t* addr_source, uint32_t byte_length)
 {
     uint32_t  temp_addr;
@@ -295,7 +295,7 @@ done_encrypt_write_4B:
   esp_rom_spiflash_write_encrypted_disable();
   return result;
 }
-#endif // (ESP32S3 && !ESP32S3BETA2) || ESP32P4
+#endif // (ESP32S3 && !ESP32S3BETA2) || ESP32P4 || ESP32C5
 
 esp_command_error handle_flash_begin(uint32_t total_size, uint32_t offset) {
   fs.in_flash_mode = true;
@@ -499,7 +499,7 @@ void handle_flash_data(void *data_buf, uint32_t length) {
     {}
 
   /* do the actual write */
-  #if (ESP32S3 && !ESP32S3BETA2) || ESP32P4
+  #if (ESP32S3 && !ESP32S3BETA2) || ESP32P4 || ESP32C5
       if (large_flash_mode){
         res = SPIWrite4B(1, fs.next_write, data_buf, length);
       } else {
@@ -551,7 +551,7 @@ void handle_flash_encrypt_data(void *data_buf, uint32_t length) {
   /* do the actual write */
 #if ESP32
   res = esp_rom_spiflash_write_encrypted(fs.next_write, data_buf, length);
-#elif (ESP32S3 && !ESP32S3BETA2) || ESP32P4
+#elif (ESP32S3 && !ESP32S3BETA2) || ESP32P4 || ESP32C5
   if (large_flash_mode){
     res = SPI_Encrypt_Write_4B(fs.next_write, data_buf, length);
   } else {


### PR DESCRIPTION
## Description

This PR adds support for flash sizes larger than 16 MB on the ESP32-C5 chip by enabling 32-bit addressing mode. The implementation follows the same pattern already established for ESP32-S3 and ESP32-P4 chips.

Key changes:

    Extended conditional compilation directives to include ESP32-C5 alongside ESP32-S3 and ESP32-P4
    Added ROM function symbols for ESP32-C5 in the linker script
    Updated comments to reflect ESP32-C5 support for large flash

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
Ran the[ `test_esptool.py`](https://github.com/espressif/esptool/blob/master/test/test_esptool.py) for ESP32-C5 with 32 MB flashing enabled, [`test_last_bytes_of_32M_flash`](https://github.com/espressif/esptool/blob/master/test/test_esptool.py#L528) and [`test_write_larger_area_to_32M_flash`](https://github.com/espressif/esptool/blob/master/test/test_esptool.py#L542) tests if the data were properly written. Tests passed.
-->
