### PR TITLE
fix(esp32c5): Erase during flashing above 16MB

### DIFF
--- a/flasher_stub/stub_write_flash.c
+++ b/flasher_stub/stub_write_flash.c
@@ -402,7 +402,7 @@ static void start_next_erase(void)
           WRITE_REG(SPI_CMD_REG, command);
           while(READ_REG(SPI_CMD_REG) != 0) { }
       }
-      #elif ESP32P4
+      #elif ESP32P4 || ESP32C5
       if (large_flash_mode) {
         esp_rom_spiflash_wait_idle();
         spi_write_enable();


### PR DESCRIPTION
## Description
During adding support of >16 MB flashing for ESP32-C5, I missed one `#ifdef` which caused erase of parts <16 MB during flashing >16 MB.

## Testing

Generated two random binaries and wrote them to the same address above 16 MB. Added test to esptool.

