### PR TITLE
Release v1.11.1 (>16 MB support fix of macro expansion) 

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,5 +1,5 @@
 [tool.commitizen]
-version = "1.11.0"
+version = "1.11.1"
 update_changelog_on_bump = true
 tag_format = "v$version"
 changelog_start_rev = "v1.0.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.11.1 (2026-01-05)
+
+### Bug Fixes
+
+- **32_bit_addressing**: Fix >16 MB support with a correct macro expansion
+
 ## v1.11.0 (2026-01-05)
 
 ### New Features

--- a/flasher_stub/stub_flasher.c
+++ b/flasher_stub/stub_flasher.c
@@ -51,7 +51,7 @@ static uint8_t calculate_checksum(uint8_t *buf, int length)
 #if ESP32C5 || ESP32P4RC1 || ESP32P4
 /* Helper to call the correct OPIFLASH_EXEC_CMD offset in ROM based on the ECO version */
 #define OPIFLASH_EXEC_CMD_CALL(fn) \
-  fn(spi_num, mode, \
+  (fn)(spi_num, mode, \
       cmd, cmd_bit_len, \
       addr, addr_bit_len, \
       dummy_bits, \


### PR DESCRIPTION
### Bug Fixes

- **32_bit_addressing**: Fix >16 MB support with a correct macro expansion