### PR TITLE
ci: fix DangerJS workflow permissions

### DIFF
--- a/.github/workflows/dangerjs.yml
+++ b/.github/workflows/dangerjs.yml
@@ -6,17 +6,12 @@ on:
 
 permissions:
   pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   pull-request-style-linter:
     runs-on: ubuntu-latest
     steps:
-    - name: Check out PR head
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-
     - name: DangerJS pull request linter
       uses: espressif/shared-github-dangerjs@v1
       env:


### PR DESCRIPTION
Security update: Modifies DangerJS workflow permissions from `contents: write` to `contents: read`.

**Enable workflow `.github/workflows/dangerjs.yml` when this merged - currently disabled!**